### PR TITLE
Build and publish binaries for tags

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,12 +24,19 @@ jobs:
 
     strategy:
       matrix:
-        os:
-        - macos-latest
-        - ubuntu-latest
-        - windows-latest
+        target:
+        - x86_64-apple-darwin
+        - x86_64-pc-windows-msvc
+        - x86_64-unknown-linux-gnu
+        include:
+        - target: x86_64-apple-darwin
+          os:     macos-latest
+        - target: x86_64-pc-windows-msvc
+          os:     windows-latest
+        - target: x86_64-unknown-linux-gnu
+          os:     ubuntu-latest
 
-    runs-on: ${{matrix.os}}
+    runs-on: ${{ matrix.os }}
 
     env:
       RUSTFLAGS: "--deny warnings"
@@ -56,6 +63,7 @@ jobs:
 
     - name: Install Rust Toolchain Components
       run: |
+        rustup target add ${{ matrix.target }}
         rustup component add clippy rustfmt
 
     - name: Info
@@ -90,3 +98,23 @@ jobs:
       run: |
         cargo install --path .
         agora --version
+
+    - name: Package
+      id: package
+      if: startsWith(github.ref, 'refs/tags/')
+      shell: bash
+      env:
+        TARGET: ${{ matrix.target }}
+        REF: ${{ github.ref }}
+        OS: ${{ matrix.os }}
+      run: ./bin/package
+
+    - name: Publish
+      uses: softprops/action-gh-release@v1
+      if: startsWith(github.ref, 'refs/tags/')
+      with:
+        draft: false
+        files: ${{ steps.package.outputs.archive }}
+        prerelease: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -109,9 +109,9 @@ jobs:
         OS: ${{ matrix.os }}
       run: ./bin/package
 
-    - name: Pre-release Check
-      id: prerelease
-      run: cargo run -p prerelease -- --reference ${{ github.ref }}
+    - name: Prerelease Check
+      id: is_prerelease
+      run: cargo run --package prerelease -- --reference ${{ github.ref }}
 
     - name: Publish
       uses: softprops/action-gh-release@v0.1.5
@@ -119,6 +119,6 @@ jobs:
       with:
         draft: false
         files: ${{ steps.package.outputs.archive }}
-        prerelease: ${{ steps.prerelease.outputs.value }}
+        prerelease: ${{ steps.is_prerelease.outputs.value }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,11 +30,11 @@ jobs:
         - x86_64-unknown-linux-gnu
         include:
         - target: x86_64-apple-darwin
-          os:     macos-latest
+          os: macos-latest
         - target: x86_64-pc-windows-msvc
-          os:     windows-latest
+          os: windows-latest
         - target: x86_64-unknown-linux-gnu
-          os:     ubuntu-latest
+          os: ubuntu-latest
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -63,8 +63,9 @@ jobs:
 
     - name: Install Rust Toolchain Components
       run: |
-        rustup target add ${{ matrix.target }}
         rustup component add clippy rustfmt
+        rustup target add ${{ matrix.target }}
+        rustup default `cat rust-toolchain`-${{ matrix.target }}
 
     - name: Info
       run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -109,17 +109,9 @@ jobs:
         OS: ${{ matrix.os }}
       run: ./bin/package
 
-    - name: Prerelease Check
+    - name: Pre-release Check
       id: prerelease
-      if: startsWith(github.ref, 'refs/tags/')
-      run: |
-        REF=${{ github.ref }}
-        VERSION=${REF#"refs/tags/"}
-        if [[ $VERSION =~ ^v[[:digit:]]+[.][[:digit:]]+[.][[:digit:]]+$ ]]; then
-          echo "::set-output name=value::false"
-        else
-          echo "::set-output name=value::true"
-        fi
+      run: cargo run -p prerelease -- --reference ${{ github.ref }}
 
     - name: Publish
       uses: softprops/action-gh-release@v0.1.5

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -109,12 +109,24 @@ jobs:
         OS: ${{ matrix.os }}
       run: ./bin/package
 
+    - name: Prerelease Check
+      id: prerelease
+      if: startsWith(github.ref, 'refs/tags/')
+      run: |
+        REF=${{ github.ref }}
+        VERSION=${REF#"refs/tags/"}
+        if [[ $VERSION =~ ^v[[:digit:]]+[.][[:digit:]]+[.][[:digit:]]+$ ]]; then
+          echo "::set-output name=value::false"
+        else
+          echo "::set-output name=value::true"
+        fi
+
     - name: Publish
       uses: softprops/action-gh-release@v0.1.5
       if: startsWith(github.ref, 'refs/tags/')
       with:
         draft: false
         files: ${{ steps.package.outputs.archive }}
-        prerelease: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+        prerelease: ${{ steps.prerelease.outputs.value }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -110,7 +110,7 @@ jobs:
       run: ./bin/package
 
     - name: Publish
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@v0.1.5
       if: startsWith(github.ref, 'refs/tags/')
       with:
         draft: false

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -103,7 +103,6 @@ jobs:
     - name: Package
       id: package
       if: startsWith(github.ref, 'refs/tags/')
-      shell: bash
       env:
         TARGET: ${{ matrix.target }}
         REF: ${{ github.ref }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "ansi_term"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -664,9 +673,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.3.4"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
+checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
 
 [[package]]
 name = "mime"
@@ -926,6 +935,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
+name = "prerelease"
+version = "0.0.0"
+dependencies = [
+ "executable-path",
+ "regex",
+ "structopt",
+]
+
+[[package]]
 name = "pretty_assertions"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1090,6 +1108,23 @@ checksum = "8270314b5ccceb518e7e578952f0b72b88222d02e8f77f5ecf7abbb673539041"
 dependencies = [
  "bitflags",
 ]
+
+[[package]]
+name = "regex"
+version = "1.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
 name = "remove_dir_all"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,9 @@ resolver = "2"
 repository = "https://github.com/soenkehahn/agora"
 homepage = "https://github.com/soenkehahn/agora"
 
+[workspace]
+members = [".", "bin/prerelease"]
+
 [dependencies]
 bytes = "1.0.1"
 futures = "0.3.14"

--- a/README.md
+++ b/README.md
@@ -14,7 +14,11 @@ $ curl http://localhost:1234/files/file.txt
 
 See `agora --help` for more configuration options.
 
-## Building
+## Installation
+
+Pre-built binaries for Linux, MacOS, and Windows can be found on [the releases page](https://github.com/soenkehahn/agora/releases).
+
+## Building from Source
 
 `agora` is written in [Rust](https://www.rust-lang.org/) and built with `cargo`.
 You can install Rust with [rustup](https://rustup.rs/).

--- a/bin/package
+++ b/bin/package
@@ -42,7 +42,7 @@ case $OS in
     tar czf $ARCHIVE *
     echo "::set-output name=archive::$ARCHIVE"
     ;;
-  windows-2016)
+  windows-latest)
     ARCHIVE=$DIST/$BIN-$VERSION-$TARGET.zip
     7z a $ARCHIVE *
     echo "::set-output name=archive::`pwd -W`/$BIN-$VERSION-$TARGET.zip"

--- a/bin/package
+++ b/bin/package
@@ -12,7 +12,7 @@ echo "Building $BIN..."
 
 case $OS in
   ubuntu-latest | macos-latest)
-    cargo rustc --bin $BIN --target $TARGET --release
+    cargo build --bin $BIN --target $TARGET --release
     EXECUTABLE=target/$TARGET/release/$BIN
     ;;
   windows-latest)

--- a/bin/package
+++ b/bin/package
@@ -9,8 +9,6 @@ BIN=agora
 
 echo "Packaging $BIN $VERSION for $TARGET..."
 
-test -f Cargo.lock || cargo generate-lockfile
-
 echo "Building $BIN..."
 
 case $OS in

--- a/bin/package
+++ b/bin/package
@@ -18,7 +18,7 @@ case $OS in
     cargo rustc --bin $BIN --target $TARGET --release
     EXECUTABLE=target/$TARGET/release/$BIN
     ;;
-  windows-2016)
+  windows-latest)
     cargo rustc --bin $BIN --target $TARGET --release -- -C target-feature="+crt-static"
     EXECUTABLE=target/$TARGET/release/$BIN.exe
     ;;

--- a/bin/package
+++ b/bin/package
@@ -28,7 +28,6 @@ echo "Copying release files..."
 mkdir dist
 cp \
   $EXECUTABLE \
-  ATTRIBUTION.md \
   Cargo.lock \
   Cargo.toml \
   LICENSE \

--- a/bin/package
+++ b/bin/package
@@ -16,7 +16,7 @@ case $OS in
     EXECUTABLE=target/$TARGET/release/$BIN
     ;;
   windows-latest)
-    cargo rustc --bin $BIN --target $TARGET --release -- -C target-feature="+crt-static"
+    cargo rustc --bin $BIN --target $TARGET --release -- --codegen target-feature="+crt-static"
     EXECUTABLE=target/$TARGET/release/$BIN.exe
     ;;
 esac

--- a/bin/package
+++ b/bin/package
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+VERSION=${REF#"refs/tags/"}
+SRC=`pwd`
+DIST=$SRC/dist
+BIN=agora
+
+echo "Packaging $BIN $VERSION for $TARGET..."
+
+test -f Cargo.lock || cargo generate-lockfile
+
+echo "Building $BIN..."
+
+case $OS in
+  ubuntu-latest | macos-latest)
+    cargo rustc --bin $BIN --target $TARGET --release
+    EXECUTABLE=target/$TARGET/release/$BIN
+    ;;
+  windows-2016)
+    cargo rustc --bin $BIN --target $TARGET --release -- -C target-feature="+crt-static"
+    EXECUTABLE=target/$TARGET/release/$BIN.exe
+    ;;
+esac
+
+echo "Copying release files..."
+mkdir dist
+cp \
+  $EXECUTABLE \
+  ATTRIBUTION.md \
+  Cargo.lock \
+  Cargo.toml \
+  LICENSE \
+  README.md \
+  $DIST
+
+cd $DIST
+echo "Creating release archive..."
+case $OS in
+  ubuntu-latest | macos-latest)
+    ARCHIVE=$DIST/$BIN-$VERSION-$TARGET.tar.gz
+    tar czf $ARCHIVE *
+    echo "::set-output name=archive::$ARCHIVE"
+    ;;
+  windows-2016)
+    ARCHIVE=$DIST/$BIN-$VERSION-$TARGET.zip
+    7z a $ARCHIVE *
+    echo "::set-output name=archive::`pwd -W`/$BIN-$VERSION-$TARGET.zip"
+    ;;
+esac

--- a/bin/package
+++ b/bin/package
@@ -3,8 +3,7 @@
 set -euxo pipefail
 
 VERSION=${REF#"refs/tags/"}
-SRC=`pwd`
-DIST=$SRC/dist
+DIST=`pwd`/dist
 BIN=agora
 
 echo "Packaging $BIN $VERSION for $TARGET..."

--- a/bin/prerelease/Cargo.toml
+++ b/bin/prerelease/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "prerelease"
+version = "0.0.0"
+authors = ["Casey Rodarmor <casey@rodarmor.com>"]
+edition = "2018"
+publish = false
+
+[dependencies]
+regex = "1.5.4"
+structopt = "0.3.21"
+
+[dev-dependencies]
+executable-path = "1.0.0"

--- a/bin/prerelease/src/main.rs
+++ b/bin/prerelease/src/main.rs
@@ -1,0 +1,20 @@
+use regex::Regex;
+use structopt::StructOpt;
+
+#[derive(StructOpt)]
+struct Arguments {
+  #[structopt(long)]
+  reference: String,
+}
+
+fn main() {
+  let arguments = Arguments::from_args();
+
+  let regex = Regex::new("^refs/tags/v[[:digit:]]+[.][[:digit:]]+[.][[:digit:]]+$")
+    .expect("Failed to compile release regex");
+
+  println!(
+    "::set-output name=value::{}",
+    !regex.is_match(&arguments.reference)
+  );
+}

--- a/bin/prerelease/tests/integration.rs
+++ b/bin/prerelease/tests/integration.rs
@@ -1,0 +1,42 @@
+use executable_path::executable_path;
+use std::{process::Command, str};
+
+fn stdout(reference: &str) -> String {
+  let output = Command::new(executable_path("prerelease"))
+    .args(&["--reference", reference])
+    .output()
+    .unwrap();
+
+  assert!(output.status.success());
+
+  String::from_utf8(output.stdout).unwrap()
+}
+
+#[test]
+fn junk_is_prerelease() {
+  assert_eq!(stdout("refs/tags/asdf"), "::set-output name=value::true\n");
+}
+
+#[test]
+fn valid_version_is_not_prerelease() {
+  assert_eq!(
+    stdout("refs/tags/v0.0.0"),
+    "::set-output name=value::false\n"
+  );
+}
+
+#[test]
+fn valid_version_with_trailing_characters_is_prerelease() {
+  assert_eq!(
+    stdout("refs/tags/v0.0.0-rc1"),
+    "::set-output name=value::true\n"
+  );
+}
+
+#[test]
+fn valid_version_with_lots_of_digits_is_not_prerelease() {
+  assert_eq!(
+    stdout("refs/tags/v01232132.098327498374.43268473849734"),
+    "::set-output name=value::false\n"
+  );
+}


### PR DESCRIPTION
This builds and publishes an archive containing binaries for every tag pushed to github. All tags not starting with a `v` are marked as pre-releases. This is a hack so that only new version tags are marked as actual releases. I'm going to see if I can match a regex like `v[0-9]+\.[0-9]+\.[0-9]+` instead. (Update: There is no way to match strings with regexes T_T)

Also, this switches to a target-based build matrix instead of an OS-based build matrix. This doesn't have any effect right now, but will make it easier to build and test for different targets in the future.

I was thinking about also switching to musl for the release binaries, but figured we could do that in a follow-up PR.