### PR TITLE
Make ./bin/forbid fail when ripgrep is not installed

### DIFF
--- a/bin/forbid
+++ b/bin/forbid
@@ -2,6 +2,7 @@
 
 set -euxo pipefail
 
+which rg
 ! rg \
   --glob !bin/forbid \
   --ignore-case \


### PR DESCRIPTION
`bash` is crazy.