### PR TITLE
Improve snafu visibility attribute

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -8,7 +8,7 @@ use tokio::task::JoinError;
 pub(crate) type Result<T, E = Error> = std::result::Result<T, E>;
 
 #[derive(Debug, Snafu)]
-#[snafu(visibility = "pub(crate)")]
+#[snafu(visibility(pub(crate)))]
 pub(crate) enum Error {
   #[snafu(display("Failed to resolve `{}` to an IP address: {}", input, source))]
   AddressResolutionIo { input: String, source: io::Error },


### PR DESCRIPTION
This changed since I first use it. It now no longer has to be a string.